### PR TITLE
fixes for summer update 2023

### DIFF
--- a/Utilla/GamemodeManager.cs
+++ b/Utilla/GamemodeManager.cs
@@ -8,6 +8,7 @@ using System.Reflection;
 using System.Linq.Expressions;
 using Photon.Pun;
 using Utilla.Models;
+using HarmonyLib;
 
 namespace Utilla
 {
@@ -203,8 +204,15 @@ namespace Utilla
 			prefab.AddComponent(gamemode.GameManager);
 			prefab.AddComponent<PhotonView>();
 
+			/*
 			DefaultPool pool = PhotonNetwork.PrefabPool as DefaultPool;
 			pool.ResourceCache.Add(BasePrefabPath + prefab.name, prefab);
+			*/
+
+			PhotonPrefabPool pool = PhotonNetwork.PrefabPool as PhotonPrefabPool;
+			FieldInfo hiddenPrefabDict = AccessTools.Field(typeof(PhotonPrefabPool), "networkPrefabs");
+			Dictionary<string, GameObject> prefabDict = hiddenPrefabDict.GetValue(pool) as Dictionary<string, GameObject>;
+			prefabDict.Add(BasePrefabPath + prefab.name, prefab);
 		}
 
 		internal void OnRoomJoin(object sender, Events.RoomJoinedArgs args)

--- a/Utilla/GamemodeSelector.cs
+++ b/Utilla/GamemodeSelector.cs
@@ -63,6 +63,7 @@ namespace Utilla
 
 				GameObject.Destroy(button.GetComponent<ModeSelectButton>());
 				button.AddComponent<PageButton>().onPressed += onPressed;
+				button.GetComponent<PageButton>().onPressButton = new UnityEngine.Events.UnityEvent();
 
 				if (!button.GetComponentInParent<Canvas>())
 				{

--- a/Utilla/Utilla.cs
+++ b/Utilla/Utilla.cs
@@ -10,13 +10,14 @@ using Photon.Pun;
 namespace Utilla
 {
 
-	[BepInPlugin("org.legoandmars.gorillatag.utilla", "Utilla", "1.6.8")]
+	[BepInPlugin("org.legoandmars.gorillatag.utilla", "Utilla", "1.6.9")]
     public class Utilla : BaseUnityPlugin
     {
         static Events events = new Events();
 
         void Start()
         {
+            DontDestroyOnLoad(this);
             RoomUtils.RoomCode = RoomUtils.RandomString(6); // Generate a random room code in case we need it
 
             GameObject dataObject = new GameObject();
@@ -33,7 +34,9 @@ namespace Utilla
 
         void PostInitialized(object sender, EventArgs e)
 		{
+            // GameObject.DontDestroyOnLoad(this.gameObject);
             var go = new GameObject("CustomGamemodesManager");
+            GameObject.DontDestroyOnLoad(go);
             var gmm = go.AddComponent<GamemodeManager>();
             this.gameObject.GetComponent<UtillaNetworkController>().gameModeManager = gmm;
 		}


### PR DESCRIPTION
- Don't destroy on load, in Start, prevents the bepinex manager gameobject from getting destroyed, so all mods work.
- fixed nullref from a new UnityEvent field added to GorillaPressableButton, being invoked on press.
- add the custom gamemodes to the new network prefab pool system.