### PR TITLE
remove mods custom prop to prevent mod checker abuse

### DIFF
--- a/Utilla/UtillaNetworkController.cs
+++ b/Utilla/UtillaNetworkController.cs
@@ -15,30 +15,9 @@ namespace Utilla
 {
     public class UtillaNetworkController : MonoBehaviourPunCallbacks
     {
-		[Serializable]
-		public class DataClass
-		{
-			public string[] installedIDs;
-			public string[] known;
-			public string assemblyHash;
-
-        }
-
         public static Events events;
 
         Events.RoomJoinedArgs lastRoom;
-
-		private string assemblyHash;
-		private string AssemblyHash {
-			get {
-				if (assemblyHash != null) {
-					return assemblyHash;
-				} else {
-					assemblyHash = GetAssemblyHash();
-					return assemblyHash;
-				}
-			}
-		}
 
 		public GamemodeManager gameModeManager;
   
@@ -93,28 +72,8 @@ namespace Utilla
 
             lastRoom = args;
 
-			var table = new Hashtable();
-			var mods = new DataClass();
-			mods.installedIDs = BepInEx.Bootstrap.Chainloader.PluginInfos.Select(x => x.Value.Metadata.GUID).ToArray();
-			mods.assemblyHash = AssemblyHash;
-			table.Add("mods", JsonUtility.ToJson(mods));
-			PhotonNetwork.LocalPlayer.SetCustomProperties(table);
-
 			RoomUtils.ResetQueue();
         }
-
-		private string GetAssemblyHash()
-		{
-			string hashPath = string.Concat(System.IO.Directory.GetCurrentDirectory(), "\\Gorilla Tag_Data\\Managed\\Assembly-CSharp.dll");
-			byte[] assemblyBytes = System.IO.File.ReadAllBytes(hashPath);
-
-			System.Security.Cryptography.SHA256 sha = System.Security.Cryptography.SHA256.Create();
-
-			byte[] ShaByte = sha.ComputeHash(assemblyBytes);
-            string hash = Convert.ToBase64String(ShaByte);
-
-            return hash;
-		}
 
 		public override void OnLeftRoom()
 		{


### PR DESCRIPTION
in my opinion, the bad mod checkers have caused far outweigh the few times they've been used legitimately by the gt moderators and there are many reasons to consider removing the prop:

ingame harassment:
- moderators have told us that mod checkers aren't allowed for regular people due to potential harassment from those who use them. if we don't provide a mods prop in the first place, this wouldn't be an issue and providing a mods prop in utilla enables this sort of behavior. 
- many of us are mod developers, and know eachother well enough for builds of our private projects to be given to eachother as well as using our own alpha quality mods. it'd be great to not have nosy cheaters looking at our mod lists and asking invasive questions about them.

inaccuracy: 
- cheaters can simply just mislabel their mods using an nondescriptive mod id, or use one a legitimate mod uses. keeping the mods prop would not provide any useful information in this scenario. i heard its also theoretically possible to modify other players custom props to display mods they don't even have installed, however i haven't proven this as i'd rather not mess with another player's props
- cheaters can also make their own mods prop with untrue contents by either modifying utilla, or by having a mod that changes the custom props after utilla sets theirs.
- this also doesnt rule out the possibility of a player having cracked versions of mods installed, like an unlocked version of bark that works in all rooms for example
- mod checkers also rely on the knowledge and judgement of the player who is using it. one could misidentify a mod as a cheat when it isn't, or accuse someone of using a leaked mod even if they acquired it legitimately.
- most players have no way to access this info, so someone without a mod checker at all could blame a player with no mods for having a cheat when they don't, and there's no way for anybody to prove them right or wrong.

redundancy:
- the mods prop is not vital to any part of utilla - you can remove the code that adds the custom property to you and the code that calculates your assembly hash and everything should still work as intended.
- 9 times out of 10 people with mod menus are blatantly cheating anyway so you wouldn't need a mod checker to tell they're using a cheat. for the 1/10 that *doesn't* make it obvious, there's not really any indication for a moderator to check anyway.
- some cheat menus create their own prop that identifies you as a user of the menu anyway. shibagt dark creates a "Dark" property with the value "true" that you could check for if needed. however, this could also potentially be altered/faked by other players as described in bullet 2, or be removed by the respective cheat developers, and shouldn't be trusted for the same reasons.
- most cheaters get banned by anticheat and/or regular player reports. the amount of cheaters who run into actual moderators are slim compared to how many get banned by anticheat/regular reports, and that's assuming the moderator would even use the mod checker in the first place and have it on hand.

mod checkers can be inaccurate, and the circumstances in which they are useful are so rare that it has almost no difference when it comes to moderating the game. the mods custom property is almost exclusively used by cheaters and nosy people bothering mod developers. ive been in multiple situations where people (both in and out of modded rooms) looked at my mods property and started asking random questions about the mods i have, many of which are unreleased and cant be acquired. 

a haunted army has explained these vulnerabilities in the mods prop system in the modding discord before, and from what i can interpret out of their messages apparently has a mod checker that doesnt rely on the mods prop at all which makes this method sort of useless

potential replacements:
- anticheat reports: there are ways to see anticheat and player reports on the fly in lobbies and you can use that as a way to identify cheaters. water mods, snowball spammers, etc etc.. most mod menus trigger anticheat reports (often times for rpc spam) even if they dont necessarily automatically ban you.
- cosmetx detection: you can use a few harmony patches to run isitemallowed when your client equips cosmetics on vrrigs. catch its output, if it isnt allowed flag them and display that in some way alongside the display name of that cosmetic. i have a relatively accurate working proof of concept that is now on a private github repo proving this is possible.
- there could some way to report a player's mod list in an encrypted, signed, or encoded form. you could encrypt the outgoing string with functions in a precompiled C/C++ native unity plugin, as they are much harder to decompile than IL, and you can load them dynamically at runtime for use in your monobehaviors *without* needing access to the original unity project. then, moderators, head modders, verifed modders, etc. can decrypt or decode the prop they get and have their mods list with a relatively high certainty that no other player can read it. ofcourse people could still just change the input given to the encryption tools, but it at least prevents regular people from reading that

the above options are either harder to tamper with or harder to read compared to a basic photon custom property and could provide close to or identical results